### PR TITLE
Update/clarify sections, fade outdated labs.

### DIFF
--- a/_includes/talk-in-index.html
+++ b/_includes/talk-in-index.html
@@ -6,7 +6,7 @@
   {% assign color = "border-danger" %}
 {% endif %}
 
-<div class="bd-callout {{ color }} pl-3">
+<div class="bd-callout {{ color }} pl-3 {% if post.title contains "(2020)" %}faded{% endif %}">
 	<div class="font-weight-bold text-dark" >
 	 <a class="text-dark" href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
 	</div>

--- a/css/main.css
+++ b/css/main.css
@@ -20,6 +20,30 @@ body {
 	border-left: 3px solid;
 }
 
+.notice {
+    border-left: 4px solid lightgray;
+    padding: 0.2rem 0 0.2rem 0.4rem;
+}
+
+.notice-warning {
+	background-color: #fcf8e3;
+	border-color: #f1c40f;
+}
+
+.notice-danger {
+	background-color: #f2dede;
+	border-color: #e74c3c;
+}
+
+.notice-success {
+	background-color: #dff0d8;
+	border-color: #2ecc71;
+}
+
+.faded {
+	opacity: 0.5;
+}
+
 /* blog */
 
 .blog h1 {

--- a/project/_posts/2021/2021-09-03-lab0b.md
+++ b/project/_posts/2021/2021-09-03-lab0b.md
@@ -20,8 +20,6 @@ redirect_from:
 
 We use the Git version control system with https://gitlab.ewi.tudelft.nl to manage submissions and grade assignments. You can access EWI GitLab with you NetID.
 
-Did you already register for EWI GitLab (before 2019), but with a different username than your NetID? We need to change it to prevent issues with single sign-on.
-
-To setup your individual repository, we need to know your NetID. Please provide it in your answer to [this question](https://weblab.tudelft.nl/cs4200/2021-2022/assignment/87898/view) on WebLab. If your GitLab username is different than your NetID, provide it in your answer too. We will then update your GitLab username.
+To setup your individual repository, we need to know your NetID. Please provide it in your answer to [this question](https://weblab.tudelft.nl/cs4200/2021-2022/assignment/87898/view) on WebLab. If your GitLab username is different than your NetID, provide it in your answer too.
 
 If you are in doubt about your answer, check the model answer by clicking the A button in the top right corner.

--- a/project/_posts/2021/2021-09-07-lab1a.md
+++ b/project/_posts/2021/2021-09-07-lab1a.md
@@ -35,8 +35,26 @@ Follow the tutorial on [Creating a language project](https://www.spoofax.dev/spo
 
 ### ChocoPy Project
 
-Create a Spoofax project for the ChocoPy language. Make sure to name your project `chocopy.syntax`, using the _root of your repository_ as the location for the project, but keep the identifier and name as `chocopy`. See the image below for an example.
+Create a Spoofax project for the ChocoPy language. Configure your project to use the Chocopy name and `cpy` identifier, and place it in the _root of your repository_. See the image below for an example.
 
 ![](https://i.imgur.com/wFAbX9K.png)
+
+Your project can be located in either `student-<yournetid>/chocopy.syntax` or `student-<yournetid>/chocopy`. If you place your project in a nested folder, or in a differently named folder, the grader will automatically reject your submission.
+
+### Updating Spoofax
+
+During the course of the project, bugfixes and new features may be added to Spoofax 3. The grader will always test your project using the most recent version of Spoofax 3 that is backwards compatible with the initial project version (0.11.6).
+
+To update your local installation to the newest version of Spoofax 3, launch Eclipse and select `Help` from the top menu, followed by `Install new software`.
+
+![](https://i.imgur.com/P8v2gj9.png)
+
+In the dialog that opens, enter the release URL of the latest Spoofax 3 release in the `Work with:` field. This URL starts with `https://artifacts.metaborg.org` and can be found on the [Spoofax 3 releases page](https://www.spoofax.dev/spoofax-pie/develop/release/download/). After entering the URL, hit enter to load all available packages for that release, then select the Spoofax package.
+
+![](https://i.imgur.com/j0Q91n8.png)
+
+Finally, hit next, accept the license if needed, and confirm the install. During installation, Eclipse may prompt that the package is unsigned. When this happens, select `Install anyway`.
+
+![](https://i.imgur.com/sKLxdGp.png)
 
 ### References

--- a/project/_posts/2021/2021-09-07-lab1b.md
+++ b/project/_posts/2021/2021-09-07-lab1b.md
@@ -68,7 +68,7 @@ To read more on SPT, visit the documentation.
 #### ChocoPy Syntax Definition
 
 To write your own test cases, you need to understand ChocoPy's syntax.
-You can find the definitive ChocoPy syntax definition in the [Reference Manual](/project/lab/0b).
+You can find the definitive ChocoPy syntax definition in the [Reference Manual]({{site.baseurl}}/lab/0b).
 
 ### Test Cases
 

--- a/project/_posts/2021/2021-09-07-lab1c.md
+++ b/project/_posts/2021/2021-09-07-lab1c.md
@@ -23,7 +23,7 @@ In this lab, you define the concrete and abstract syntax of ChocoPy in Spoofax.
 From this definition, you generate an Eclipse editor, which provides syntax checking, error recovery, and syntax highlighting.
 
 In this lab, focus on translating the grammar in Figure 3 of the ChocoPy Reference Manual to an _idiomatic_ context-free syntax definition with constructors.
-In the [next lab](), you extend this definition with _disambiguation rules_ for associativity, priority, and layout constraints.
+In the [next lab]({{site.baseurl}}/lab/2), you extend this definition with _disambiguation rules_ for associativity, priority, and layout constraints.
 
 ### Objectives
 
@@ -38,7 +38,7 @@ The definition should include:
 ### Syntax Definition
 
 You should define your syntax in SDF3.
-You can start by opening the file `src/start.sdf3` in your `chocopy.syntax` project.
+You can start by opening the file `src/start.sdf3` in your chocopy project.
 You can also split your syntax definition over several modules in `src/` and import modules into module `start`.
 
 ```
@@ -55,6 +55,11 @@ This module provides syntax definitions for common lexical sorts such as identif
 
 <!-- For more information on how to write SDF3 syntax definitions, also check the documentation on how to define a language in Spoofax.
 {: .notice .notice-warning} -->
+
+For more information on how to write SDF3 syntax definitions, you can also review the [old SDF3 reference manual](http://www.metaborg.org/en/latest/source/langdev/meta/lang/sdf3/index.html) and the new [SDF3 reference](https://www.spoofax.dev/references/syntax/).
+
+**Note that both of these are written for Spoofax 2, and that not all information may still be correct in Spoofax 3!**
+{: .notice .notice-warning}
 
 #### Context-free Syntax
 
@@ -105,8 +110,8 @@ lexical syntax
 #### Testing Your Syntax Definition
 
 You now can check your tests.
-It is important to get your grammar working at this stage. Do not move on if you have issues here, since there is a high chance that these issues influence your other tests as well.
-If you experience weird behaviour on your tests, this is most likely caused by an erroneous definition of `LAYOUT`.
+
+It is important to get your grammar working at this stage. Do not move on if you have issues here, since there is a high chance that these issues influence your other tests as well. If you experience weird behaviour on your tests or a large amount of ambiguity, this is most likely caused by an erroneous definition of `LAYOUT`.
 {: .notice .notice-danger}
 
 Finally, you should add lexical syntax rules for comments to your syntax definition.

--- a/project/_posts/2021/2021-09-07-submissions.md
+++ b/project/_posts/2021/2021-09-07-submissions.md
@@ -47,13 +47,13 @@ To actually do work in the Git repository, you need to make a *local* clone of t
 Open up the command line and make a local clone with your URL:
 
 ```shell
-git clone https://gitlab.ewi.tudelft.nl/CS4200/2021-2022/student-id.git
+git clone https://gitlab.ewi.tudelft.nl/CS4200/2021-2022/student-netid.git
 ```
 
 Now cd into the local clone and confirm that it works:
 
 ```shell
-cd student-id
+cd student-netid
 git status
 ```
 
@@ -69,7 +69,7 @@ Your local repository is set up now! Follow the steps below to work on an assign
 
 ### Starting an assignment
 
-You work on each assignment in its own development branch, named `milestone-0-develop`, `milestone-0-develop`, etc.
+You work on each assignment in its own development branch, named `milestone-0-develop`, `milestone-1-develop`, etc.
 The correct assignment branch must be checked out in your local Git repository to be able to work on it.
 The steps to check out a branch depend on whether we provide you with a template, or if you continue with work from a previous assignment.
 

--- a/project/_posts/2021/2021-09-10-milestone0.md
+++ b/project/_posts/2021/2021-09-10-milestone0.md
@@ -26,12 +26,11 @@ Testing that your GitLab repository works with our automatic grading set-up.
 
 Your repository should consist of (at least) the following:
 
-1. A Spoofax project located in the `chocopy.syntax` folder
-1. The project should contain examples
-1. The project should contain tests
-1. Your language project builds
-1. Your language project uses `Program` as start symbol
-1. Your language project parses a program consisting of just `1`
+1. A Spoofax project located in either the `chocopy.syntax` (preferred) or `chocopy` subfolder of your repository
+1. The project should contain at least one example.
+1. The project should contain at least one test.
+1. Your language project builds.
+1. Your language project parses a program consisting of just `1`.
 
 ### Submission
 

--- a/project/_posts/2021/2021-09-14-lab2.md
+++ b/project/_posts/2021/2021-09-14-lab2.md
@@ -108,4 +108,6 @@ Section 3.1 describes the meaning of these tokens.
 
 Translate these tokens into _layout constraints_ and _layout declarations_ as presented in [Lecture 3]({{site.baseurl}}/lecture/3) and in the papers cited below.
 
+Additional documentation on layout constraints can also be found in the [Spoofax 2 documentation](https://www.spoofax.dev/references/syntax/layout-sensitivity/). **Please note that this documentation is for Spoofax 2, and may therefore not fully correspond to Spoofax 3 behavior.**
+
 ### References


### PR DESCRIPTION
- Reword some sections.
- Remove some outdated milestone 0 requirements (different start symbol, support for both `chocopy.syntax` and `chocopy`).
- Add css for alerts/warnings.
- Fade out project sections for old 2020 content to try and prevent more Spoofax 2vs3 confusion.
- Add instructions on how to update Spoofax